### PR TITLE
Fix build error: check fscanf return value

### DIFF
--- a/src/components/tl/dpu/tl_dpu_context.c
+++ b/src/components/tl/dpu/tl_dpu_context.c
@@ -116,29 +116,30 @@ UCC_CLASS_INIT_FUNC(ucc_tl_dpu_context_t,
                 if (strcmp(h, hname) == 0) {
                     for (i = 0; i < 2 * MAX_DPU_COUNT; i++) {
                         memset(dpu_tmp, 0, MAX_DPU_HOST_NAME);
-                        fscanf(fp, "%s", dpu_tmp);
+                        if (fscanf(fp, "%s", dpu_tmp) != EOF) {
 
-                        if(strchr(dpu_tmp, ',') != NULL)
-                        {
-                            last_dpu_found = 1;
-                            /* remove the tail (,) */
-                            memmove(&dpu_tmp[strlen(dpu_tmp) - 1], &dpu_tmp[strlen(dpu_tmp)], 1);
-                        }
-
-                        if(strstr(dpu_tmp, "mlx5_") != NULL) {
-                            memcpy(dpu_hcanames[hca], dpu_tmp, MAX_DPU_HCA_NAME);
-                            hca++;
-                            if(last_dpu_found) { 
-                                break;
+                            if(strchr(dpu_tmp, ',') != NULL)
+                            {
+                                last_dpu_found = 1;
+                                /* remove the tail (,) */
+                                memmove(&dpu_tmp[strlen(dpu_tmp) - 1], &dpu_tmp[strlen(dpu_tmp)], 1);
                             }
-                            continue;
-                        } 
 
-                        memcpy(dpu_hnames[rail], dpu_tmp, MAX_DPU_HOST_NAME);
-                        rail++;                        
+                            if(strstr(dpu_tmp, "mlx5_") != NULL) {
+                                memcpy(dpu_hcanames[hca], dpu_tmp, MAX_DPU_HCA_NAME);
+                                hca++;
+                                if(last_dpu_found) {
+                                    break;
+                                }
+                                continue;
+                            }
 
-                        tl_info(self->super.super.lib, "DPU <%s> found!\n",
-                                dpu_tmp);
+                            memcpy(dpu_hnames[rail], dpu_tmp, MAX_DPU_HOST_NAME);
+                            rail++;
+
+                            tl_info(self->super.super.lib, "DPU <%s> found!\n",
+                                    dpu_tmp);
+                        }
 
                         if(last_dpu_found) { 
                             break;


### PR DESCRIPTION
## What
Fix build error: check fscanf return value

## Why ?
Building the UCC from dpu-v0.3.x branch encountered the following error:
``` 
/hpc/mtr_scrap/users/pengwang/ucc-demo/ucc/src/components/tl/dpu/tl_dpu_context.c: In function ‘ucc_tl_dpu_context_t_init’:
/hpc/mtr_scrap/users/pengwang/ucc-demo/ucc/src/components/tl/dpu/tl_dpu_context.c:119:25: error: ignoring return value of ‘fscanf’, declared with attribute warn_unused_result [-Werror=unused-result]
  119 |                         fscanf(fp, "%s", dpu_tmp);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:595: libucc_tl_dpu_la-tl_dpu_context.lo] Error 1
```

By using `-Werror` as build as the build flag, it treats warnings as errors. In UCC code, it need check the `fscanf` return value to avoid warnings.

## How ?
Need check the `fscanf` return value to avoid warnings.
